### PR TITLE
修复android16 不断崩溃问题 

### DIFF
--- a/platform/hidden-api/src/main/java/bridge/ProcessObserverAdapter.java
+++ b/platform/hidden-api/src/main/java/bridge/ProcessObserverAdapter.java
@@ -22,4 +22,10 @@ public class ProcessObserverAdapter extends IProcessObserver.Stub {
     public void onForegroundServicesChanged(int pid, int uid, int serviceTypes) throws RemoteException {
         // from Q beta 3
     }
+
+    // Android 15/16 (API 35/36): empty default keeps older stub receivers crash-free
+    // when system_server dispatches the new process-start callback.
+    @Override
+    public void onProcessStarted(int pid, int uid, int processType, String hostingType, String hostingName) throws RemoteException {
+    }
 }

--- a/platform/hidden-api/src/main/java/stub/android/app/IProcessObserver.java
+++ b/platform/hidden-api/src/main/java/stub/android/app/IProcessObserver.java
@@ -15,6 +15,10 @@ public interface IProcessObserver {
     // from Q beta 3
     void onForegroundServicesChanged(int pid, int uid, int serviceTypes) throws RemoteException;
 
+    // added on Android 15/16 (API 35/36); required to dispatch process-start events.
+    // Missing override on the stub receiver causes AbstractMethodError on API 36.
+    void onProcessStarted(int pid, int uid, int processType, String hostingType, String hostingName) throws RemoteException;
+
     abstract class Stub extends Binder implements IProcessObserver {
 
     }

--- a/runtime/cleaner-server/src/main/java/me/gm/cleaner/runtime/server/BinderSender.java
+++ b/runtime/cleaner-server/src/main/java/me/gm/cleaner/runtime/server/BinderSender.java
@@ -47,6 +47,17 @@ public class BinderSender {
                 onActive(uid, pid);
             }
         }
+
+        // Android 15/16 (API 36): system_server dispatches onProcessStarted for new processes.
+        // Registering here gives a native, logcat-free process-start signal (and avoids the
+        // AbstractMethodError crash that killed the server on every new app start on API 36).
+        @Override
+        public void onProcessStarted(final int pid, final int uid, final int processType,
+                                     final String hostingType, final String hostingName) {
+            if (PID_SET.add(pid)) {
+                onActive(uid, pid);
+            }
+        }
     }
 
     private static class UidObserver extends UidObserverAdapter {


### PR DESCRIPTION
已编译测试 之前错误日志 
AndroidRuntime: FATAL EXCEPTION: binder:443_5
AndroidRuntime: PID: 443
AndroidRuntime: java.lang.AbstractMethodError: abstract method "void android.app.IProcessObserver.onProcessStarted(int, int, int, java.lang.String, java.lang.String)" on receiver java.lang.Class<me.gm.cleaner.runtime.server.BinderSender$ProcessObserver>
AndroidRuntime:  at android.app.IProcessObserver$Stub.onTransact(IProcessObserver.java:127)
AndroidRuntime:  at android.os.Binder.execTransactInternal(Binder.java:1478)
AndroidRuntime:  at android.os.Binder.execTransact(Binder.java:1418)